### PR TITLE
(ref #1) Modify resulting weight computation

### DIFF
--- a/src/MultiDimensionsHierarchies/Aggregator.cs
+++ b/src/MultiDimensionsHierarchies/Aggregator.cs
@@ -64,7 +64,7 @@ namespace MultiDimensionsHierarchies
             /* Aggregate base data that might have common keys */
             groupAggregator ??= ( items ) => items.Aggregate( aggregator );
             var seqInputs = inputs.GroupBy( x => x.Key )
-                .Select( g => g.Aggregate( g.Key , groupAggregator , weightEffect ) )
+                .Select( g => g.Aggregate( g.Key , groupAggregator ) )
                 .ToSeq();
 
             weightEffect ??= ( t , _ ) => t;
@@ -93,7 +93,8 @@ namespace MultiDimensionsHierarchies
                     {
                         foreach ( var ancestor in skeleton.Key.Ancestors() )
                         {
-                            var weight = skeleton.Key.ResultingWeight( ancestor );
+                            //var weight = skeleton.Key.ResultingWeight( ancestor );
+                            var weight = Skeleton.ComputeResultingWeight( skeleton.Key , ancestor );
                             results.AddOrUpdate( ancestor , skeleton.Value ,
                                 ( _ , data ) =>
                                     data.Some( d => skeleton.Value

--- a/src/MultiDimensionsHierarchies/Aggregator.cs
+++ b/src/MultiDimensionsHierarchies/Aggregator.cs
@@ -63,21 +63,21 @@ namespace MultiDimensionsHierarchies
 
             /* Aggregate base data that might have common keys */
             groupAggregator ??= ( items ) => items.Aggregate( aggregator );
-            var seqInputs = inputs.GroupBy( x => x.Key )
+            var groupedInputs = inputs.GroupBy( x => x.Key )
                 .Select( g => g.Aggregate( g.Key , groupAggregator ) )
-                .ToSeq();
+                .ToArray();
 
             weightEffect ??= ( t , _ ) => t;
 
             return method switch
             {
-                Method.Targeted => TargetedAggregate( seqInputs , seqTargets , groupAggregator , weightEffect ),
-                Method.Heuristic => HeuristicAggregate( seqInputs , aggregator , seqTargets , weightEffect ),
+                Method.Targeted => TargetedAggregate( groupedInputs , seqTargets , groupAggregator , weightEffect ),
+                Method.Heuristic => HeuristicAggregate( groupedInputs , aggregator , seqTargets , weightEffect ),
                 _ => new AggregationResult<T>( AggregationStatus.NO_RUN , TimeSpan.Zero , "No method was defined." )
             };
         }
 
-        private static AggregationResult<T> HeuristicAggregate<T>( Seq<Skeleton<T>> baseData ,
+        private static AggregationResult<T> HeuristicAggregate<T>( Skeleton<T>[] baseData ,
                                                                   Func<T , T , T> aggregator ,
                                                                   Seq<Skeleton> targets ,
                                                                   Func<T , double , T> weightEffect )
@@ -119,7 +119,7 @@ namespace MultiDimensionsHierarchies
             return f.Match( res => res , exc => new AggregationResult<T>( AggregationStatus.ERROR , TimeSpan.Zero , exc.Message ) );
         }
 
-        private static AggregationResult<T> TargetedAggregate<T>( Seq<Skeleton<T>> baseData ,
+        private static AggregationResult<T> TargetedAggregate<T>( Skeleton<T>[] baseData ,
                                                                  Seq<Skeleton> targets ,
                                                                  Func<IEnumerable<T> , T> groupAggregator ,
                                                                  Func<T , double , T> weightEffect )
@@ -134,7 +134,7 @@ namespace MultiDimensionsHierarchies
                     .ToSeq();
 
                 var simplifiedTargets = targets;
-                var simplifiedData = baseData;
+                var simplifiedData = Seq.createRange( baseData );
                 if ( uniqueTargetBaseBones.Any() )
                 {
                     var uniqueDimensions = uniqueTargetBaseBones.Select( u => u.DimensionName ).ToArray();

--- a/src/MultiDimensionsHierarchies/Core/Skeleton.Extensions.cs
+++ b/src/MultiDimensionsHierarchies/Core/Skeleton.Extensions.cs
@@ -19,12 +19,15 @@ namespace MultiDimensionsHierarchies.Core
         }
 
         public static Skeleton<T> Aggregate<T>( this IEnumerable<Skeleton<T>> skeletons ,
-            Skeleton key , Func<IEnumerable<T> , T> aggregator , Func<T , double , T> weightEffect = null )
+            Skeleton key , Func<IEnumerable<T> , T> aggregator )
+            => new( aggregator( skeletons.Select( s => s.Value ).Somes() ) , key );
+
+        public static Skeleton<T> Aggregate<T>( this IEnumerable<Skeleton<T>> skeletons ,
+            Skeleton key , Func<IEnumerable<T> , T> aggregator , Func<T , double , T> weightEffect )
         {
-            weightEffect ??= ( t , _ ) => t;
             return new( aggregator( skeletons.Select( o =>
             {
-                var w = o.Key.ResultingWeight( key );
+                var w = Skeleton.ComputeResultingWeight( o.Key , key );
                 return o.Value.Some( v => Option<(T, double)>.Some( (v, w) ) ).None( () => Option<(T, double)>.None );
             } ).Somes()
             .Select( t => weightEffect( t.Item1 , t.Item2 ) ) ) , key );

--- a/src/MultiDimensionsHierarchies/MultiDimensionsHierarchies.csproj
+++ b/src/MultiDimensionsHierarchies/MultiDimensionsHierarchies.csproj
@@ -18,4 +18,10 @@
 		<PackageReference Include="morelinq" Version="3.3.2" />
 	</ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>TestMultiDimensionsHierarchies</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/TestMultiDimensionsHierarchies/BoneTests.cs
+++ b/src/TestMultiDimensionsHierarchies/BoneTests.cs
@@ -109,15 +109,28 @@ public class BoneTests
 
         var gc = root.Descendants().Find( b => b.Label.Equals( "Grand Child 1.1" ) );
         var c = root.Descendants().Find( b => b.Label.Equals( "Child 1" ) );
-        gc.ShouldBeSome( bgc =>
-        {
-            bgc.ResultingWeight( bgc ).Should().Be( 1d );
-            c.ShouldBeSome( bc =>
-            {
-                bgc.ResultingWeight( bc ).Should().Be( 0.5 );
-                bc.ResultingWeight( root ).Should().Be( .9 );
-                bgc.ResultingWeight( root ).Should().Be( 0.45 );
-            } );
-        } );
+        //gc.ShouldBeSome( bgc =>
+        //{
+        //    bgc.ResultingWeight( bgc ).Should().Be( 1d );
+        //    c.ShouldBeSome( bc =>
+        //    {
+        //        bgc.ResultingWeight( bc ).Should().Be( 0.5 );
+        //        bc.ResultingWeight( root ).Should().Be( .9 );
+        //        bgc.ResultingWeight( root ).Should().Be( 0.45 );
+        //    } );
+        //} );
+
+        var weight = from current in gc
+                     select Bone.ComputeResultingWeight( current , root );
+        weight.ShouldBeSome( w => w.Should().Be( .45 ) );
+
+        weight = from current in c
+                 select Bone.ComputeResultingWeight( current , root );
+        weight.ShouldBeSome( w => w.Should().Be( .9 ) );
+
+        weight = from current in gc
+                 from ancestor in c
+                 select Bone.ComputeResultingWeight( current , ancestor );
+        weight.ShouldBeSome( w => w.Should().Be( .5 ) );
     }
 }

--- a/src/TestMultiDimensionsHierarchies/SkeletonTests.cs
+++ b/src/TestMultiDimensionsHierarchies/SkeletonTests.cs
@@ -426,21 +426,27 @@ public class SkeletonTests
             r.Descendants().Find( "1" , "0" , "1" )
                 .ShouldBeSome( s =>
                 {
-                    s.ResultingWeight( r ).Should().Be( .5 );
+                    //s.ResultingWeight( r ).Should().Be( .5 );
                     var other = items.First( s => !s.Root().Equals( r ) );
-                    other.ResultingWeight( r ).Should().Be( 0 );
+                    //other.ResultingWeight( r ).Should().Be( 0 );
+
+                    Skeleton.ComputeResultingWeight( s , r ).Should().Be( .5 );
+                    Skeleton.ComputeResultingWeight( s , other ).Should().Be( 0 );
                 } );
 
             r.Descendants().Find( "1" , "0" , "0" )
                 .ShouldBeSome( s =>
                 {
-                    s.ResultingWeight( r ).Should().Be( .25 );
+                    //s.ResultingWeight( r ).Should().Be( .25 );
+                    Skeleton.ComputeResultingWeight( s , r ).Should().Be( .25 );
+
                 } );
 
             r.Descendants().Find( "0" , "0" , "0" )
                 .ShouldBeSome( s =>
                 {
-                    s.ResultingWeight( r ).Should().Be( .125 );
+                    //s.ResultingWeight( r ).Should().Be( .125 );
+                    Skeleton.ComputeResultingWeight( s , r ).Should().Be( .125 );
                 } );
         } );
     }


### PR DESCRIPTION
- Resulting weight between bones or skeletons is now made from a static method, instead of a recursive call from the object.
- Removed weight effect from first aggregate on base data with the same key,